### PR TITLE
Fetch account name before setting account

### DIFF
--- a/src/Lynx.ts
+++ b/src/Lynx.ts
@@ -128,7 +128,8 @@ export class Lynx extends Authenticator {
   public async login(_?: string): Promise<User[]> {
     if (this.users.length === 0) {
       try {
-        const account = await window.lynxMobile.requestSetAccount()
+        const accountName = await window.lynxMobile.requestSetAccountName()
+        const account = await window.lynxMobile.requestSetAccount(accountName)
         this.users.push(new LynxUser(this.chains[0], account))
       } catch (e) {
         throw new UALLynxError(


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Fetching account name from lynx first and passing it to the requestSetAccount function to set the account correctly.
Fix for #28 



## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
